### PR TITLE
specify .xz format in tar

### DIFF
--- a/recipes/Homo_sapiens/hg38/hg38-hisat2/pre-link.sh
+++ b/recipes/Homo_sapiens/hg38/hg38-hisat2/pre-link.sh
@@ -7,6 +7,6 @@ mkdir -p $PREFIX/share/ggd/Homo_sapiens/hg38/ && cd $PREFIX/share/ggd/Homo_sapie
 
 url=https://s3.amazonaws.com/biodata/genomes/hg38-hisat2-12-07-2015.tar.xz
 wget -qO- $url > hg38-hisat2-tar.xz
-tar xvf hg38-hisat2-tar.xz
+tar xJvf hg38-hisat2-tar.xz
 rm hg38-hisat2-tar.xz
 

--- a/recipes/Homo_sapiens/hg38/hg38-hisat2/pre-link.sh
+++ b/recipes/Homo_sapiens/hg38/hg38-hisat2/pre-link.sh
@@ -7,6 +7,6 @@ mkdir -p $PREFIX/share/ggd/Homo_sapiens/hg38/ && cd $PREFIX/share/ggd/Homo_sapie
 
 url=https://s3.amazonaws.com/biodata/genomes/hg38-hisat2-12-07-2015.tar.xz
 wget -qO- $url > hg38-hisat2-tar.xz
-tar zxvf hg38-hisat2-tar.xz
+tar xvf hg38-hisat2-tar.xz
 rm hg38-hisat2-tar.xz
 


### PR DESCRIPTION
Before creating a pull-request please run `ggd check-recipe path/to/recipe-dir/`.

ggd can be install via: `pip install -U git+git://github.com/gogetdata/ggd-cli.git`

If your pull-request errors on travis-ci, follow the link and read the log carefully;
it should give information about what went wrong.

--
Fixes hg38-hisat2 uncompression, but fails on `check-recipe` due to noncanonical files.

Specifically: installing the original `hg38-hisat2` fails early because of the `tar zxvf` command forcing zip format on a .xz file. After fixing that `ggd check-recipe` fails at a later point with entries like:

```
ERROR: Homo_sapiens/hg38:hg38-hisat2(/path/to/env/share/ggd/Homo_sapiens/hg38/hisat2/hg38.4.ht2) uknown file and not in the extra/extra-files section of the yaml
```

So https://github.com/gogetdata/ggd-recipes/issues/2#issuecomment-213093385 will probably have be addressed before merging.