### PR TITLE
Test conda version with Travis

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -4,7 +4,8 @@ set -exo pipefail
 
 # NOTE: much of this is taken from bioconda.
 if [[ $TRAVIS_OS_NAME = "linux" ]]; then
-	curl -O https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+	#curl -O https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.4.10-Linux-x86_64.sh
 	sudo bash Miniconda2-latest-Linux-x86_64.sh -b -p /anaconda/
 	sudo chown -R $USER /anaconda/
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-linux_amd64


### PR DESCRIPTION
Changed http to https. 
When using conda 4.5.2 an error is produced. Testing to see if Travis is not compatible with the latest version of conda.

Before creating a pull-request please run `ggd check-recipe path/to/recipe-dir/`.

ggd can be install via: `pip install -U git+git://github.com/gogetdata/ggd-cli.git`

If your pull-request errors on travis-ci, follow the link and read the log carefully;
it should give information about what went wrong.
