### PR TITLE
Update conda version, and remove conda update

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -4,15 +4,15 @@ set -exo pipefail
 
 # NOTE: much of this is taken from bioconda.
 if [[ $TRAVIS_OS_NAME = "linux" ]]; then
-	curl -O http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
-	sudo bash Miniconda2-latest-Linux-x86_64.sh -b -p /anaconda/
+	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.31-Linux-x86_64.sh
+	sudo bash Miniconda2-4.3.31-Linux-x86_64.sh -b -p /anaconda/
 	sudo chown -R $USER /anaconda/
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-linux_amd64
 
 
 else
-	curl -O http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
-	sudo bash Miniconda2-latest-MacOSX-x86_64.sh -b -p /anaconda/
+	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.31-MacOSX-x86_64.sh
+	sudo bash Miniconda2-4.3.31-MacOSX-x86_64.sh -b -p /anaconda/
 	sudo chown -R $USER /anaconda/
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-darwin_amd64
 fi
@@ -21,7 +21,7 @@ chmod +x /anaconda/bin/check-sort-order
 mkdir -p /anaconda/conda-bld/{linux,osx}-64
 export PATH=/anaconda/bin:$PATH
 conda install -y conda-build
-conda update -y conda
+#conda update -y conda ## Remove update, latest conda version not implemented in conda-build-all
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda install -y conda-build-all --channel conda-forge


### PR DESCRIPTION
Only conda version 4.2 and 4.3 are implemented in conda-build-all.

Before creating a pull-request please run `ggd check-recipe path/to/recipe-dir/`.

ggd can be install via: `pip install -U git+git://github.com/gogetdata/ggd-cli.git`

If your pull-request errors on travis-ci, follow the link and read the log carefully;
it should give information about what went wrong.
