### PR TITLE
Update conda version, and remove conda update

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -38,7 +38,7 @@ echo "########################################################"
 
 
 
-cat /anaconda/bin/conda-build-all/conda_interface.py
+cat /anaconda/lib/python2.7/site-packages/conda_build_all/conda_interface.py
 
 
 

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -4,13 +4,13 @@ set -exo pipefail
 
 # NOTE: much of this is taken from bioconda.
 if [[ $TRAVIS_OS_NAME = "linux" ]]; then
-	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh
-	sudo bash Miniconda2-4.3.27-Linux-x86_64.sh -b -p /anaconda/
+	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.31-Linux-x86_64.sh
+	sudo bash Miniconda2-4.3.31-Linux-x86_64.sh -b -p /anaconda/
 	sudo chown -R $USER /anaconda/
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-linux_amd64
 else
-	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.27-MacOSX-x86_64.sh
-	sudo bash Miniconda2-4.3.27-MacOSX-x86_64.sh -b -p /anaconda/
+	curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.31-MacOSX-x86_64.sh
+	sudo bash Miniconda2-4.3.31-MacOSX-x86_64.sh -b -p /anaconda/
 	sudo chown -R $USER /anaconda/
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-darwin_amd64
 fi
@@ -19,7 +19,7 @@ chmod +x /anaconda/bin/check-sort-order
 mkdir -p /anaconda/conda-bld/{linux,osx}-64
 export PATH=/anaconda/bin:$PATH
 conda install -y conda-build
-conda update -y conda
+#conda update -y conda ## Remove update, latest conda version not implemented in conda-build-all
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda install -y conda-build-all --channel conda-forge

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -27,3 +27,4 @@ conda install -y conda-build anaconda-client
 pip install -U git+git://github.com/gogetdata/ggd-cli.git
 conda install -y "gsort>=0.0.2" samtools htslib zlib
 conda info -a #for debugging
+conda --version ## Get conda version 

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -15,6 +15,10 @@ else
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-darwin_amd64
 fi
 
+echo "########################################################"
+conda --version ## Get conda version 
+echo "########################################################"
+
 chmod +x /anaconda/bin/check-sort-order
 mkdir -p /anaconda/conda-bld/{linux,osx}-64
 export PATH=/anaconda/bin:$PATH
@@ -27,4 +31,7 @@ conda install -y conda-build anaconda-client
 pip install -U git+git://github.com/gogetdata/ggd-cli.git
 conda install -y "gsort>=0.0.2" samtools htslib zlib
 conda info -a #for debugging
+
+echo "########################################################"
 conda --version ## Get conda version 
+echo "########################################################"

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -36,7 +36,10 @@ echo "########################################################"
 conda --version ## Get conda version 
 echo "########################################################"
 
-echo "\n\n\n"
-cat /anaconda/bin/conda-build-all
-echo "\n\n\n"
+
+
+cat /anaconda/bin/conda-build-all/conda_interface.py
+
+
+
 

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -15,14 +15,14 @@ else
 	curl -Lo /anaconda/bin/check-sort-order https://github.com/gogetdata/ggd-utils/releases/download/v0.0.3/check-sort-order-darwin_amd64
 fi
 
-echo "########################################################"
-conda --version ## Get conda version 
-echo "########################################################"
 
 chmod +x /anaconda/bin/check-sort-order
 mkdir -p /anaconda/conda-bld/{linux,osx}-64
 export PATH=/anaconda/bin:$PATH
 conda install -y conda-build
+echo "########################################################"
+conda --version ## Get conda version 
+echo "########################################################"
 #conda update -y conda ## Remove update, latest conda version not implemented in conda-build-all
 conda config --add channels bioconda
 conda config --add channels conda-forge

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -35,3 +35,8 @@ conda info -a #for debugging
 echo "########################################################"
 conda --version ## Get conda version 
 echo "########################################################"
+
+echo "\n\n\n"
+cat /anaconda/bin/conda-build-all
+echo "\n\n\n"
+

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -25,6 +25,8 @@ rmbuild() {
 }
 trap rmbuild EXIT
 
+conda --version ## Get conda version 
+
 conda-build-all \
 	--inspect-channels=ggd-alpha \
 	--artefact-directory $CHECK_DIR \


### PR DESCRIPTION
Only conda version 4.2 and 4.3 are implemented in conda-build-all.

Before creating a pull-request please run `ggd check-recipe path/to/recipe-dir/`.

ggd can be install via: `pip install -U git+git://github.com/gogetdata/ggd-cli.git`

If your pull-request errors on travis-ci, follow the link and read the log carefully;
it should give information about what went wrong.
